### PR TITLE
fix: require the SDK utils directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# percy-nightwatch
+# @percy/nightwatch
 
 [![Package Status](https://img.shields.io/npm/v/@percy/nightwatch.svg)](https://www.npmjs.com/package/@percy/nightwatch) [![This project is using Percy.io for visual regression testing.](https://percy.io/static/images/percy-badge.svg)](https://percy.io/percy/percy-nightwatch) [![CircleCI](https://circleci.com/gh/percy/percy-nightwatch.svg?style=svg)](https://circleci.com/gh/percy/percy-nightwatch)
 

--- a/lib/percySnapshot.ts
+++ b/lib/percySnapshot.ts
@@ -1,7 +1,6 @@
 import fs = require('fs')
-import { agentJsFilename } from '@percy/agent'
 import { clientInfo } from './environment'
-
+const { agentJsFilename } = require('@percy/agent/dist/utils/sdk-utils')
 declare var PercyAgent: any
 
 /**
@@ -23,7 +22,7 @@ export function command(this: any, name: string, options: any = {}) {
       const percyAgentClient = new PercyAgent({ clientInfo })
       percyAgentClient.snapshot(name, options)
     },
-    [name, options, clientInfo()]
+    [name, options, clientInfo()],
   )
 }
 


### PR DESCRIPTION
Require these SDK util functions directly to avoid having to include them in the main `@percy/agent` bundle which causes issues as it mixes code that should go into the browser vs code that should run in node.

Related issue: https://github.com/percy/percy-cypress/issues/58