### PR TITLE
fix: Loosen the `@percy/agent` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -616,7 +616,7 @@
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-ify": {
@@ -1689,7 +1689,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -2470,7 +2470,7 @@
     },
     "globby": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
@@ -3579,7 +3579,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "minimist-options": {
@@ -8190,7 +8190,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1024,9 +1024,9 @@
       }
     },
     "chromedriver": {
-      "version": "73.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-73.0.0.tgz",
-      "integrity": "sha512-RnZOTgAa3prPmA1QDHtrsEhppDGiosND5O/0ukWwGuU+EglCBHvYl1x3Mh/YypMIkmydRyq50XPrNYZadsM6rQ==",
+      "version": "2.46.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-2.46.0.tgz",
+      "integrity": "sha512-dLtKIJW3y/PuFrPmcw6Mb8Nh+HwSqgVrK1rWgTARXhHfWvV822X2VRkx2meU/tg2+YQL6/nNgT6n5qWwIDHbwg==",
       "dev": true,
       "requires": {
         "del": "^3.0.0",
@@ -2470,7 +2470,7 @@
     },
     "globby": {
       "version": "6.1.0",
-      "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@percy/agent": "^0.3.1"
+    "@percy/agent": "~0"
   },
   "release": {
     "plugins": [

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@percy/tslint": "^1.0.0",
     "@semantic-release/changelog": "^3.0.2",
     "@semantic-release/git": "^7.0.8",
-    "chromedriver": "^73.0.0",
+    "chromedriver": "2.46.0",
     "http-server": "^0.11.1",
     "nightwatch": "^1.0.14",
     "selenium-server": "^3.141.59",


### PR DESCRIPTION
## What is this? 

This PR is just like the one opened on the Cypress SDK: https://github.com/percy/percy-cypress/pull/92

It allows us to resolve to all 0.x.x versions of agent. 