### PR TITLE
feat: PER-7348 add waitForReady() call before serialize()

### DIFF
--- a/commands/percySnapshot.js
+++ b/commands/percySnapshot.js
@@ -1,7 +1,7 @@
 // Collect client and environment information
 const sdkPkg = require('../package.json');
 const nightwatchPkg = require('nightwatch/package.json');
-const { captureDOM } = require('../lib/snapshot');
+const { captureDOM, waitForReady } = require('../lib/snapshot');
 const { createRegion } = require('../lib/regions');
 const CLIENT_INFO = `${sdkPkg.name}/${sdkPkg.version}`;
 const ENV_INFO = `${nightwatchPkg.name}/${nightwatchPkg.version}`;
@@ -43,8 +43,16 @@ module.exports = class PercySnapshotCommand {
       // Inject the DOM serialization script
       await injectPercyDOM(this.api, domScript);
 
+      // Readiness gate — runs before serialize when CLI supports it (PER-7348).
+      const readinessDiagnostics = await waitForReady(this.api, options, utils, log);
+
       // Serialize and capture the DOM
       let { domSnapshot, url } = await captureDOM(this.api, options, utils, log, domScript);
+
+      // Attach readiness diagnostics so the CLI can log timing and pass/fail
+      if (readinessDiagnostics && domSnapshot && typeof domSnapshot === 'object' && !Array.isArray(domSnapshot)) {
+        domSnapshot.readiness_diagnostics = readinessDiagnostics;
+      }
 
       // Filter out DOM-only serialization options that shouldn't be posted to Percy
       const {

--- a/commands/percySnapshot.js
+++ b/commands/percySnapshot.js
@@ -43,7 +43,7 @@ module.exports = class PercySnapshotCommand {
       // Inject the DOM serialization script
       await injectPercyDOM(this.api, domScript);
 
-      // Readiness gate — runs before serialize when CLI supports it (PER-7348).
+      // Readiness gate — runs before serialize when CLI supports it.
       const readinessDiagnostics = await waitForReady(this.api, options, utils, log);
 
       // Serialize and capture the DOM

--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -65,7 +65,7 @@ function executeAsyncScript(browser, fn, args = []) {
   });
 }
 
-// Readiness gate (PER-7348). Runs *before* serialize when CLI exposes
+// Readiness gate. Runs *before* serialize when CLI exposes
 // PercyDOM.waitForReady. Falls back silently on older CLI builds and never
 // blocks snapshot capture. Uses sdk-utils.waitForReadyScript({ callback: true })
 // as the shared in-browser invoker — uses `arguments[arguments.length - 1]`

--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -65,33 +65,18 @@ function executeAsyncScript(browser, fn, args = []) {
   });
 }
 
-// In-browser readiness invoker. Defined at module scope so the typeof
-// guard branches are unit-testable in Node against a stubbed `PercyDOM`
-// global — that's how we cover the body without `istanbul ignore`. The
-// driver injects the `done` callback as the trailing argument, hence
-// `arguments[arguments.length - 1]` instead of a named parameter; tests
-// invoke this function directly with a positional `done` and the same
-// expression resolves to it.
-function browserWaitForReady(config) {
-  var done = arguments[arguments.length - 1];
-  try {
-    /* eslint-disable-next-line no-undef */
-    if (typeof PercyDOM !== 'undefined' && typeof PercyDOM.waitForReady === 'function') {
-      /* eslint-disable-next-line no-undef */
-      PercyDOM.waitForReady(config).then(function(d) { done(d); }).catch(function() { done(); });
-    } else { done(); }
-  } catch (e) { done(); }
-}
-
 // Readiness gate (PER-7348). Runs *before* serialize when CLI exposes
 // PercyDOM.waitForReady. Falls back silently on older CLI builds and never
-// blocks snapshot capture.
+// blocks snapshot capture. Uses sdk-utils.waitForReadyScript({ callback: true })
+// as the shared in-browser invoker — uses `arguments[arguments.length - 1]`
+// for the executeAsync done callback.
 async function waitForReady(browser, options = {}, utils, log) {
-  const readinessConfig = options.readiness || utils?.percy?.config?.snapshot?.readiness || {};
-  if (readinessConfig.preset === 'disabled') return undefined;
+  if (!utils?.waitForReadyScript) return undefined; // old sdk-utils
+  if (utils.isReadinessDisabled(options)) return undefined;
 
+  const script = utils.waitForReadyScript(utils.getReadinessConfig(options), { callback: true });
   try {
-    return await executeAsyncScript(browser, browserWaitForReady, [readinessConfig || {}]);
+    return await executeAsyncScript(browser, script);
   } catch (error) {
     log?.debug?.(`waitForReady failed, proceeding to serialize: ${error?.message || error}`);
     return undefined;
@@ -415,6 +400,5 @@ module.exports = {
   slowScrollToBottom,
   ignoreCanvasSerializationErrors,
   ignoreStyleSheetSerializationErrors,
-  waitForReady,
-  __test__: { browserWaitForReady }
+  waitForReady
 };

--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -71,27 +71,19 @@ function executeAsyncScript(browser, fn, args = []) {
 // as the shared in-browser invoker — uses `arguments[arguments.length - 1]`
 // for the executeAsync done callback.
 async function waitForReady(browser, options = {}, utils, log) {
-  // Helpers require @percy/sdk-utils 1.31.14+; degrade to a no-op on older
-  // versions (possible in resolved lockfiles even when package.json floors
-  // are bumped) instead of crashing snapshot capture.
-  if (typeof utils?.waitForReadyScript !== 'function') return undefined;
-
-  const readinessDisabled = typeof utils.isReadinessDisabled === 'function'
-    ? utils.isReadinessDisabled(options)
-    : ((options?.readiness || utils.percy?.config?.snapshot?.readiness)?.preset === 'disabled');
-  if (readinessDisabled) return undefined;
-
-  const readinessConfig = typeof utils.getReadinessConfig === 'function'
-    ? utils.getReadinessConfig(options)
-    : { ...(utils.percy?.config?.snapshot?.readiness || {}), ...(options?.readiness || {}) };
-
-  const script = utils.waitForReadyScript(readinessConfig, { callback: true });
-  try {
-    return await executeAsyncScript(browser, script);
-  } catch (error) {
-    log?.debug?.(`waitForReady failed, proceeding to serialize: ${error?.message || error}`);
-    return undefined;
-  }
+  // All readiness orchestration (disabled check + shallow-merge config +
+  // callback-mode script generation + try/catch) lives in @percy/sdk-utils
+  // 1.31.15+ as runReadinessGate. Degrade to no-op when the helper is
+  // absent — same behaviour as an old CLI without PercyDOM.waitForReady.
+  if (typeof utils?.runReadinessGate !== 'function') return undefined;
+  const result = await utils.runReadinessGate(
+    (script) => executeAsyncScript(browser, script),
+    options,
+    { callback: true, log }
+  );
+  // sdk-utils returns null on no-op / failure; nightwatch's contract is
+  // `undefined`, so normalise.
+  return result == null ? undefined : result;
 }
 
 function getCookies(browser) {

--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -71,10 +71,21 @@ function executeAsyncScript(browser, fn, args = []) {
 // as the shared in-browser invoker — uses `arguments[arguments.length - 1]`
 // for the executeAsync done callback.
 async function waitForReady(browser, options = {}, utils, log) {
-  if (!utils?.waitForReadyScript) return undefined; // old sdk-utils
-  if (utils.isReadinessDisabled(options)) return undefined;
+  // Helpers require @percy/sdk-utils 1.31.14+; degrade to a no-op on older
+  // versions (possible in resolved lockfiles even when package.json floors
+  // are bumped) instead of crashing snapshot capture.
+  if (typeof utils?.waitForReadyScript !== 'function') return undefined;
 
-  const script = utils.waitForReadyScript(utils.getReadinessConfig(options), { callback: true });
+  const readinessDisabled = typeof utils.isReadinessDisabled === 'function'
+    ? utils.isReadinessDisabled(options)
+    : ((options?.readiness || utils.percy?.config?.snapshot?.readiness)?.preset === 'disabled');
+  if (readinessDisabled) return undefined;
+
+  const readinessConfig = typeof utils.getReadinessConfig === 'function'
+    ? utils.getReadinessConfig(options)
+    : { ...(utils.percy?.config?.snapshot?.readiness || {}), ...(options?.readiness || {}) };
+
+  const script = utils.waitForReadyScript(readinessConfig, { callback: true });
   try {
     return await executeAsyncScript(browser, script);
   } catch (error) {

--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -41,6 +41,52 @@ function executeScript(browser, fn, args = []) {
   });
 }
 
+function executeAsyncScript(browser, fn, args = []) {
+  return new Promise((resolve, reject) => {
+    try {
+      const cb = result => {
+        let value = unwrapResult(result);
+        if (result && result.status && result.status !== 0 && result.error) {
+          return reject(result.error);
+        }
+        resolve(value);
+      };
+
+      if (typeof browser.executeAsync === 'function') {
+        browser.executeAsync(fn, args, cb);
+      } else if (typeof browser.executeAsyncScript === 'function') {
+        browser.executeAsyncScript(fn, args, cb);
+      } else {
+        resolve(undefined);
+      }
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+// Readiness gate (PER-7348). Runs *before* serialize when CLI exposes
+// PercyDOM.waitForReady. Falls back silently on older CLI builds and never
+// blocks snapshot capture.
+async function waitForReady(browser, options = {}, utils, log) {
+  const readinessConfig = options.readiness || utils?.percy?.config?.snapshot?.readiness || {};
+  if (readinessConfig.preset === 'disabled') return undefined;
+
+  try {
+    return await executeAsyncScript(browser, function(config) {
+      var done = arguments[arguments.length - 1];
+      /* eslint-disable-next-line no-undef */
+      if (typeof PercyDOM !== 'undefined' && typeof PercyDOM.waitForReady === 'function') {
+        /* eslint-disable-next-line no-undef */
+        PercyDOM.waitForReady(config).then(function(d) { done(d); }).catch(function() { done(); });
+      } else { done(); }
+    }, [readinessConfig || {}]);
+  } catch (error) {
+    log?.debug?.(`waitForReady failed, proceeding to serialize: ${error?.message || error}`);
+    return undefined;
+  }
+}
+
 function getCookies(browser) {
   if (typeof browser.getCookies !== 'function') return Promise.resolve([]);
   return new Promise((resolve, reject) => {
@@ -357,5 +403,6 @@ module.exports = {
   captureDOM,
   slowScrollToBottom,
   ignoreCanvasSerializationErrors,
-  ignoreStyleSheetSerializationErrors
+  ignoreStyleSheetSerializationErrors,
+  waitForReady
 };

--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -65,6 +65,24 @@ function executeAsyncScript(browser, fn, args = []) {
   });
 }
 
+// In-browser readiness invoker. Defined at module scope so the typeof
+// guard branches are unit-testable in Node against a stubbed `PercyDOM`
+// global — that's how we cover the body without `istanbul ignore`. The
+// driver injects the `done` callback as the trailing argument, hence
+// `arguments[arguments.length - 1]` instead of a named parameter; tests
+// invoke this function directly with a positional `done` and the same
+// expression resolves to it.
+function browserWaitForReady(config) {
+  var done = arguments[arguments.length - 1];
+  try {
+    /* eslint-disable-next-line no-undef */
+    if (typeof PercyDOM !== 'undefined' && typeof PercyDOM.waitForReady === 'function') {
+      /* eslint-disable-next-line no-undef */
+      PercyDOM.waitForReady(config).then(function(d) { done(d); }).catch(function() { done(); });
+    } else { done(); }
+  } catch (e) { done(); }
+}
+
 // Readiness gate (PER-7348). Runs *before* serialize when CLI exposes
 // PercyDOM.waitForReady. Falls back silently on older CLI builds and never
 // blocks snapshot capture.
@@ -73,14 +91,7 @@ async function waitForReady(browser, options = {}, utils, log) {
   if (readinessConfig.preset === 'disabled') return undefined;
 
   try {
-    return await executeAsyncScript(browser, function(config) {
-      var done = arguments[arguments.length - 1];
-      /* eslint-disable-next-line no-undef */
-      if (typeof PercyDOM !== 'undefined' && typeof PercyDOM.waitForReady === 'function') {
-        /* eslint-disable-next-line no-undef */
-        PercyDOM.waitForReady(config).then(function(d) { done(d); }).catch(function() { done(); });
-      } else { done(); }
-    }, [readinessConfig || {}]);
+    return await executeAsyncScript(browser, browserWaitForReady, [readinessConfig || {}]);
   } catch (error) {
     log?.debug?.(`waitForReady failed, proceeding to serialize: ${error?.message || error}`);
     return undefined;
@@ -404,5 +415,6 @@ module.exports = {
   slowScrollToBottom,
   ignoreCanvasSerializationErrors,
   ignoreStyleSheetSerializationErrors,
-  waitForReady
+  waitForReady,
+  __test__: { browserWaitForReady }
 };

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test:types": "tsd"
   },
   "dependencies": {
-    "@percy/sdk-utils": "^1.31.14",
+    "@percy/sdk-utils": "^1.31.15-beta.0",
     "@percy/selenium-webdriver": "^2.2.3"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test:types": "tsd"
   },
   "dependencies": {
-    "@percy/sdk-utils": "^1.31.4",
+    "@percy/sdk-utils": "^1.31.14",
     "@percy/selenium-webdriver": "^2.2.3"
   },
   "peerDependencies": {

--- a/test/unit/snapshot.test.js
+++ b/test/unit/snapshot.test.js
@@ -7,8 +7,7 @@ const {
   ignoreCanvasSerializationErrors,
   ignoreStyleSheetSerializationErrors,
   slowScrollToBottom,
-  waitForReady,
-  __test__: { browserWaitForReady }
+  waitForReady
 } = require('../../lib/snapshot');
 
 describe('snapshot helpers', () => {
@@ -120,7 +119,7 @@ describe('snapshot helpers', () => {
         capturedScript: null,
         capturedArgs: null,
         executeAsync(fn, args, cb) {
-          this.capturedScript = fn.toString();
+          this.capturedScript = fn;
           this.capturedArgs = args;
           if (throwError) throw throwError;
           cb({ value: asyncResult });
@@ -128,37 +127,63 @@ describe('snapshot helpers', () => {
       };
     }
 
+    // Minimal sdk-utils stub. The real helpers live in @percy/sdk-utils; we
+    // exercise the contract here (string emission, callback-mode shape, JSON
+    // inlining) without pulling in the package — keeps these unit tests fast.
+    function makeUtils({ globalReadiness } = {}) {
+      return {
+        percy: { config: { snapshot: globalReadiness ? { readiness: globalReadiness } : {} } },
+        waitForReadyScript: (cfg, opts) => {
+          const config = JSON.stringify(cfg);
+          if (opts?.callback) {
+            return `var done = arguments[arguments.length - 1];
+              try {
+                if (typeof PercyDOM !== 'undefined' && typeof PercyDOM.waitForReady === 'function') {
+                  PercyDOM.waitForReady(${config}).then(function(r) { done(r); }).catch(function() { done(); });
+                } else { done(); }
+              } catch(e) { done(); }`;
+          }
+          return `PercyDOM.waitForReady(${config})`;
+        },
+        isReadinessDisabled: (options) => {
+          const merged = { ...(globalReadiness || {}), ...(options?.readiness || {}) };
+          return merged.preset === 'disabled';
+        },
+        getReadinessConfig: (options) =>
+          ({ ...(globalReadiness || {}), ...(options?.readiness || {}) })
+      };
+    }
+
     it('returns diagnostics when the CLI exposes waitForReady', async () => {
       const diagnostics = { timed_out: false, duration_ms: 12 };
       const browser = makeBrowser({ asyncResult: diagnostics });
 
-      const result = await waitForReady(browser, {}, { percy: { config: {} } });
+      const result = await waitForReady(browser, {}, makeUtils());
 
       expect(result).toEqual(diagnostics);
-      // The injected script must use executeAsync semantics (done callback)
+      expect(typeof browser.capturedScript).toBe('string');
       expect(browser.capturedScript).toContain('arguments[arguments.length - 1]');
       expect(browser.capturedScript).toContain('PercyDOM.waitForReady');
-      expect(browser.capturedArgs).toEqual([{}]);
+      // sdk-utils inlines the config in the script — no separate args needed.
+      expect(browser.capturedArgs).toEqual([]);
     });
 
-    it('passes per-snapshot readiness config through to the browser', async () => {
+    it('inlines per-snapshot readiness config as JSON into the script', async () => {
       const browser = makeBrowser({ asyncResult: undefined });
       const config = { preset: 'strict', stabilityWindowMs: 500 };
 
-      await waitForReady(browser, { readiness: config }, { percy: { config: {} } });
+      await waitForReady(browser, { readiness: config }, makeUtils());
 
-      expect(browser.capturedArgs).toEqual([config]);
+      expect(browser.capturedScript).toContain('"preset":"strict"');
+      expect(browser.capturedScript).toContain('"stabilityWindowMs":500');
     });
 
     it('falls back to .percy.yml readiness config when no per-snapshot value is given', async () => {
       const browser = makeBrowser({ asyncResult: undefined });
-      const utils = {
-        percy: { config: { snapshot: { readiness: { preset: 'fast' } } } }
-      };
 
-      await waitForReady(browser, {}, utils);
+      await waitForReady(browser, {}, makeUtils({ globalReadiness: { preset: 'fast' } }));
 
-      expect(browser.capturedArgs).toEqual([{ preset: 'fast' }]);
+      expect(browser.capturedScript).toContain('"preset":"fast"');
     });
 
     it('skips waitForReady entirely when preset is disabled', async () => {
@@ -167,8 +192,17 @@ describe('snapshot helpers', () => {
       const result = await waitForReady(
         browser,
         { readiness: { preset: 'disabled' } },
-        { percy: { config: {} } }
+        makeUtils()
       );
+
+      expect(result).toBe(undefined);
+      expect(browser.capturedScript).toBe(null);
+    });
+
+    it('is a silent no-op when sdk-utils lacks waitForReadyScript (older sdk-utils)', async () => {
+      const browser = makeBrowser({ asyncResult: { should: 'not see this' } });
+
+      const result = await waitForReady(browser, {}, { percy: { config: {} } });
 
       expect(result).toBe(undefined);
       expect(browser.capturedScript).toBe(null);
@@ -178,7 +212,7 @@ describe('snapshot helpers', () => {
       const browser = makeBrowser({ throwError: new Error('selenium boom') });
       const log = { debugCalls: [], debug(...args) { this.debugCalls.push(args); } };
 
-      const result = await waitForReady(browser, {}, { percy: { config: {} } }, log);
+      const result = await waitForReady(browser, {}, makeUtils(), log);
 
       expect(result).toBe(undefined);
       expect(log.debugCalls.length).toBe(1);
@@ -191,7 +225,7 @@ describe('snapshot helpers', () => {
       const browser = makeBrowser({ throwError: 'plain-string-rejection' });
       const log = { debugCalls: [], debug(...args) { this.debugCalls.push(args); } };
 
-      const result = await waitForReady(browser, {}, { percy: { config: {} } }, log);
+      const result = await waitForReady(browser, {}, makeUtils(), log);
 
       expect(result).toBe(undefined);
       expect(log.debugCalls.length).toBe(1);
@@ -201,73 +235,9 @@ describe('snapshot helpers', () => {
     it('resolves with undefined when neither executeAsync nor executeAsyncScript exists', async () => {
       const browser = {}; // no execute methods at all
 
-      const result = await waitForReady(browser, {}, { percy: { config: {} } });
+      const result = await waitForReady(browser, {}, makeUtils());
 
       expect(result).toBe(undefined);
-    });
-  });
-
-  // Unit tests for the in-browser readiness invoker. Runs in Node against a
-  // stubbed `PercyDOM` global so the typeof-guard + try/catch branches get
-  // real statement/branch coverage instead of being suppressed.
-  describe('browserWaitForReady', () => {
-    afterEach(() => {
-      delete globalThis.PercyDOM;
-    });
-
-    it('invokes done with no args when PercyDOM is undefined', () => {
-      let received = 'sentinel';
-      const done = (...args) => { received = args; };
-      browserWaitForReady({ preset: 'balanced' }, done);
-      expect(received).toEqual([]);
-    });
-
-    it('invokes done with no args when PercyDOM lacks waitForReady', () => {
-      globalThis.PercyDOM = {};
-      let received = 'sentinel';
-      const done = (...args) => { received = args; };
-      browserWaitForReady({ preset: 'balanced' }, done);
-      expect(received).toEqual([]);
-    });
-
-    it('invokes done with diagnostics when PercyDOM.waitForReady resolves', async () => {
-      const diagnostics = { passed: true, preset: 'strict' };
-      let receivedConfig;
-      globalThis.PercyDOM = {
-        waitForReady(cfg) { receivedConfig = cfg; return Promise.resolve(diagnostics); }
-      };
-      let received = 'sentinel';
-      const done = (...args) => { received = args; };
-
-      browserWaitForReady({ preset: 'strict' }, done);
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
-      expect(receivedConfig).toEqual({ preset: 'strict' });
-      expect(received).toEqual([diagnostics]);
-    });
-
-    it('invokes done with no args when PercyDOM.waitForReady rejects', async () => {
-      globalThis.PercyDOM = {
-        waitForReady() { return Promise.reject(new Error('boom')); }
-      };
-      let received = 'sentinel';
-      const done = (...args) => { received = args; };
-
-      browserWaitForReady({ preset: 'balanced' }, done);
-      await new Promise((resolve) => setTimeout(resolve, 0));
-
-      expect(received).toEqual([]);
-    });
-
-    it('invokes done with no args when PercyDOM.waitForReady throws synchronously', () => {
-      globalThis.PercyDOM = {
-        waitForReady() { throw new Error('sync boom'); }
-      };
-      let received = 'sentinel';
-      const done = (...args) => { received = args; };
-
-      browserWaitForReady({ preset: 'balanced' }, done);
-      expect(received).toEqual([]);
     });
   });
 });

--- a/test/unit/snapshot.test.js
+++ b/test/unit/snapshot.test.js
@@ -7,7 +7,8 @@ const {
   ignoreCanvasSerializationErrors,
   ignoreStyleSheetSerializationErrors,
   slowScrollToBottom,
-  waitForReady
+  waitForReady,
+  __test__: { browserWaitForReady }
 } = require('../../lib/snapshot');
 
 describe('snapshot helpers', () => {
@@ -183,12 +184,90 @@ describe('snapshot helpers', () => {
       expect(log.debugCalls.length).toBe(1);
     });
 
+    it('logs the raw error when executeAsync throws a non-Error', async () => {
+      // Covers the `error?.message || error` second branch in the catch:
+      // the rejection value has no `.message`, so the log line falls through
+      // to stringifying the error itself.
+      const browser = makeBrowser({ throwError: 'plain-string-rejection' });
+      const log = { debugCalls: [], debug(...args) { this.debugCalls.push(args); } };
+
+      const result = await waitForReady(browser, {}, { percy: { config: {} } }, log);
+
+      expect(result).toBe(undefined);
+      expect(log.debugCalls.length).toBe(1);
+      expect(log.debugCalls[0][0]).toContain('plain-string-rejection');
+    });
+
     it('resolves with undefined when neither executeAsync nor executeAsyncScript exists', async () => {
       const browser = {}; // no execute methods at all
 
       const result = await waitForReady(browser, {}, { percy: { config: {} } });
 
       expect(result).toBe(undefined);
+    });
+  });
+
+  // Unit tests for the in-browser readiness invoker. Runs in Node against a
+  // stubbed `PercyDOM` global so the typeof-guard + try/catch branches get
+  // real statement/branch coverage instead of being suppressed.
+  describe('browserWaitForReady', () => {
+    afterEach(() => {
+      delete globalThis.PercyDOM;
+    });
+
+    it('invokes done with no args when PercyDOM is undefined', () => {
+      let received = 'sentinel';
+      const done = (...args) => { received = args; };
+      browserWaitForReady({ preset: 'balanced' }, done);
+      expect(received).toEqual([]);
+    });
+
+    it('invokes done with no args when PercyDOM lacks waitForReady', () => {
+      globalThis.PercyDOM = {};
+      let received = 'sentinel';
+      const done = (...args) => { received = args; };
+      browserWaitForReady({ preset: 'balanced' }, done);
+      expect(received).toEqual([]);
+    });
+
+    it('invokes done with diagnostics when PercyDOM.waitForReady resolves', async () => {
+      const diagnostics = { passed: true, preset: 'strict' };
+      let receivedConfig;
+      globalThis.PercyDOM = {
+        waitForReady(cfg) { receivedConfig = cfg; return Promise.resolve(diagnostics); }
+      };
+      let received = 'sentinel';
+      const done = (...args) => { received = args; };
+
+      browserWaitForReady({ preset: 'strict' }, done);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(receivedConfig).toEqual({ preset: 'strict' });
+      expect(received).toEqual([diagnostics]);
+    });
+
+    it('invokes done with no args when PercyDOM.waitForReady rejects', async () => {
+      globalThis.PercyDOM = {
+        waitForReady() { return Promise.reject(new Error('boom')); }
+      };
+      let received = 'sentinel';
+      const done = (...args) => { received = args; };
+
+      browserWaitForReady({ preset: 'balanced' }, done);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(received).toEqual([]);
+    });
+
+    it('invokes done with no args when PercyDOM.waitForReady throws synchronously', () => {
+      globalThis.PercyDOM = {
+        waitForReady() { throw new Error('sync boom'); }
+      };
+      let received = 'sentinel';
+      const done = (...args) => { received = args; };
+
+      browserWaitForReady({ preset: 'balanced' }, done);
+      expect(received).toEqual([]);
     });
   });
 });

--- a/test/unit/snapshot.test.js
+++ b/test/unit/snapshot.test.js
@@ -127,30 +127,34 @@ describe('snapshot helpers', () => {
       };
     }
 
-    // Minimal sdk-utils stub. The real helpers live in @percy/sdk-utils; we
-    // exercise the contract here (string emission, callback-mode shape, JSON
-    // inlining) without pulling in the package — keeps these unit tests fast.
+    // Minimal sdk-utils stub. The real helper lives in @percy/sdk-utils as
+    // runReadinessGate; we reimplement the contract here (shallow-merge,
+    // callback-mode script emission, try/catch) without pulling in the
+    // package — keeps these unit tests fast.
     function makeUtils({ globalReadiness } = {}) {
+      const mergedConfig = (options) =>
+        ({ ...(globalReadiness || {}), ...(options?.readiness || {}) });
       return {
         percy: { config: { snapshot: globalReadiness ? { readiness: globalReadiness } : {} } },
-        waitForReadyScript: (cfg, opts) => {
-          const config = JSON.stringify(cfg);
-          if (opts?.callback) {
-            return `var done = arguments[arguments.length - 1];
-              try {
-                if (typeof PercyDOM !== 'undefined' && typeof PercyDOM.waitForReady === 'function') {
-                  PercyDOM.waitForReady(${config}).then(function(r) { done(r); }).catch(function() { done(); });
-                } else { done(); }
-              } catch(e) { done(); }`;
+        runReadinessGate: async (evalScript, options, { callback = false, log } = {}) => {
+          const config = mergedConfig(options);
+          if (config.preset === 'disabled') return null;
+          const configJson = JSON.stringify(config);
+          const script = callback
+            ? `var done = arguments[arguments.length - 1];
+                try {
+                  if (typeof PercyDOM !== 'undefined' && typeof PercyDOM.waitForReady === 'function') {
+                    PercyDOM.waitForReady(${configJson}).then(function(r) { done(r); }).catch(function() { done(); });
+                  } else { done(); }
+                } catch(e) { done(); }`
+            : `PercyDOM.waitForReady(${configJson})`;
+          try {
+            return await evalScript(script);
+          } catch (err) {
+            log?.debug?.(`waitForReady failed, proceeding to serialize: ${err?.message || err}`);
+            return null;
           }
-          return `PercyDOM.waitForReady(${config})`;
-        },
-        isReadinessDisabled: (options) => {
-          const merged = { ...(globalReadiness || {}), ...(options?.readiness || {}) };
-          return merged.preset === 'disabled';
-        },
-        getReadinessConfig: (options) =>
-          ({ ...(globalReadiness || {}), ...(options?.readiness || {}) })
+        }
       };
     }
 
@@ -199,7 +203,7 @@ describe('snapshot helpers', () => {
       expect(browser.capturedScript).toBe(null);
     });
 
-    it('is a silent no-op when sdk-utils lacks waitForReadyScript (older sdk-utils)', async () => {
+    it('is a silent no-op when sdk-utils lacks runReadinessGate (older sdk-utils)', async () => {
       const browser = makeBrowser({ asyncResult: { should: 'not see this' } });
 
       const result = await waitForReady(browser, {}, { percy: { config: {} } });

--- a/test/unit/snapshot.test.js
+++ b/test/unit/snapshot.test.js
@@ -6,7 +6,8 @@ const {
   captureSerializedDOM,
   ignoreCanvasSerializationErrors,
   ignoreStyleSheetSerializationErrors,
-  slowScrollToBottom
+  slowScrollToBottom,
+  waitForReady
 } = require('../../lib/snapshot');
 
 describe('snapshot helpers', () => {
@@ -109,6 +110,85 @@ describe('snapshot helpers', () => {
       await slowScrollToBottom(browser);
 
       expect(browser.scrollCalls).toEqual([450, 900, 'top']);
+    });
+  });
+
+  describe('waitForReady (PER-7348)', () => {
+    function makeBrowser({ asyncResult, throwError } = {}) {
+      return {
+        capturedScript: null,
+        capturedArgs: null,
+        executeAsync(fn, args, cb) {
+          this.capturedScript = fn.toString();
+          this.capturedArgs = args;
+          if (throwError) throw throwError;
+          cb({ value: asyncResult });
+        }
+      };
+    }
+
+    it('returns diagnostics when the CLI exposes waitForReady', async () => {
+      const diagnostics = { timed_out: false, duration_ms: 12 };
+      const browser = makeBrowser({ asyncResult: diagnostics });
+
+      const result = await waitForReady(browser, {}, { percy: { config: {} } });
+
+      expect(result).toEqual(diagnostics);
+      // The injected script must use executeAsync semantics (done callback)
+      expect(browser.capturedScript).toContain('arguments[arguments.length - 1]');
+      expect(browser.capturedScript).toContain('PercyDOM.waitForReady');
+      expect(browser.capturedArgs).toEqual([{}]);
+    });
+
+    it('passes per-snapshot readiness config through to the browser', async () => {
+      const browser = makeBrowser({ asyncResult: undefined });
+      const config = { preset: 'strict', stabilityWindowMs: 500 };
+
+      await waitForReady(browser, { readiness: config }, { percy: { config: {} } });
+
+      expect(browser.capturedArgs).toEqual([config]);
+    });
+
+    it('falls back to .percy.yml readiness config when no per-snapshot value is given', async () => {
+      const browser = makeBrowser({ asyncResult: undefined });
+      const utils = {
+        percy: { config: { snapshot: { readiness: { preset: 'fast' } } } }
+      };
+
+      await waitForReady(browser, {}, utils);
+
+      expect(browser.capturedArgs).toEqual([{ preset: 'fast' }]);
+    });
+
+    it('skips waitForReady entirely when preset is disabled', async () => {
+      const browser = makeBrowser({ asyncResult: { should: 'not see this' } });
+
+      const result = await waitForReady(
+        browser,
+        { readiness: { preset: 'disabled' } },
+        { percy: { config: {} } }
+      );
+
+      expect(result).toBe(undefined);
+      expect(browser.capturedScript).toBe(null);
+    });
+
+    it('returns undefined and does not throw when executeAsync fails', async () => {
+      const browser = makeBrowser({ throwError: new Error('selenium boom') });
+      const log = { debugCalls: [], debug(...args) { this.debugCalls.push(args); } };
+
+      const result = await waitForReady(browser, {}, { percy: { config: {} } }, log);
+
+      expect(result).toBe(undefined);
+      expect(log.debugCalls.length).toBe(1);
+    });
+
+    it('resolves with undefined when neither executeAsync nor executeAsyncScript exists', async () => {
+      const browser = {}; // no execute methods at all
+
+      const result = await waitForReady(browser, {}, { percy: { config: {} } });
+
+      expect(result).toBe(undefined);
     });
   });
 });

--- a/test/unit/snapshot.test.js
+++ b/test/unit/snapshot.test.js
@@ -113,7 +113,7 @@ describe('snapshot helpers', () => {
     });
   });
 
-  describe('waitForReady (PER-7348)', () => {
+  describe('waitForReady', () => {
     function makeBrowser({ asyncResult, throwError } = {}) {
       return {
         capturedScript: null,


### PR DESCRIPTION
## Summary

Adds Pattern D (Selenium-style `executeAsync` for readiness, `execute` unchanged for serialize) ahead of `PercyDOM.serialize()` per PER-7348.

Pairs with: https://github.com/percy/cli/pull/2184

### Behavior

- New `waitForReady(browser, options, utils, log)` helper in `lib/snapshot.js` runs **before** `captureDOM` in `commands/percySnapshot.js`.
- The helper uses `browser.executeAsync` (falling back to `browser.executeAsyncScript`). The injected script picks up the Selenium async-callback as the last argument (`arguments[arguments.length - 1]`) and resolves either after `PercyDOM.waitForReady(config)` settles or immediately when the function isn't on the page (older CLI builds).
- `readiness.preset === 'disabled'` short-circuits — the async script is never injected.
- If `executeAsync` throws, the SDK logs at debug and proceeds to serialize. Snapshot capture is never blocked.
- Per-snapshot `options.readiness` wins over `utils.percy.config.snapshot.readiness` from `.percy.yml`.
- Diagnostics returned by `waitForReady` are attached to `domSnapshot.readiness_diagnostics` so the CLI can log timing and pass/fail.

`captureDOM` / `PercyDOM.serialize()` itself is unchanged — still synchronous via `browser.execute`.

### SDK-visible contract

```js
// New — readiness step (executeAsync, skipped on old CLI / disabled preset)
const readinessDiagnostics = await waitForReady(this.api, options, utils, log);

// Unchanged
const { domSnapshot, url } = await captureDOM(this.api, options, utils, log, domScript);
if (readinessDiagnostics) domSnapshot.readiness_diagnostics = readinessDiagnostics;
```

## Test plan

`test/unit/snapshot.test.js` — `waitForReady (PER-7348)` describe block:

- [x] Returns diagnostics when CLI exposes `waitForReady` and verifies the injected script uses `arguments[arguments.length - 1]` (Selenium async callback)
- [x] Per-snapshot `readiness` config is forwarded to the browser
- [x] Falls back to `.percy.yml` `snapshot.readiness` when no per-snapshot value is set
- [x] `readiness.preset: disabled` short-circuits — `executeAsync` is never called
- [x] Returns `undefined` and logs at debug when `executeAsync` throws
- [x] Resolves with `undefined` when neither `executeAsync` nor `executeAsyncScript` exists on the browser

```
$ yarn test:unit
14 passing (91ms)
```

Smoke test against `example-percy-nightwatch` was not run as part of this fan-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)