### PR TITLE
chore: release 2.2.1-beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/nightwatch",
   "description": "Nightwatch client library for visual testing with Percy",
-  "version": "2.2.0-beta.0",
+  "version": "2.2.1-beta.0",
   "license": "MIT",
   "author": "Perceptual Inc.",
   "repository": "https://github.com/percy/percy-nightwatch",


### PR DESCRIPTION
Beta release: PER-7348 readiness gate via @percy/sdk-utils@^1.31.15-beta.0.

Merged in: #874