### PR TITLE
security: filter session cookies + sanitize forwarded options (PER-8720, PER-8722)

### DIFF
--- a/commands/percySnapshot.js
+++ b/commands/percySnapshot.js
@@ -61,8 +61,24 @@ module.exports = class PercySnapshotCommand {
         ...snapshotOptions
       } = options;
 
+      // Sanitize caller-supplied options before spreading them into the outbound
+      // POST body (CWE-284/CWE-1321 — PER-8722): drop prototype-pollution keys
+      // and code-bearing fields the SDK must never forward. clientInfo /
+      // environmentInfo are hard-coded AFTER the spread so callers can't override.
+      const BLOCKED_OPTION_KEYS = new Set([
+        '__proto__', 'constructor', 'prototype', 'execute', 'domTransformation'
+      ]);
+      const safeOptions = {};
+      for (const key of Object.keys(snapshotOptions)) {
+        if (BLOCKED_OPTION_KEYS.has(key)) {
+          log.debug?.(`Ignoring disallowed percySnapshot option: ${key}`);
+          continue;
+        }
+        safeOptions[key] = snapshotOptions[key];
+      }
+
       const postData = {
-        ...snapshotOptions,
+        ...safeOptions,
         domSnapshot,
         environmentInfo: ENV_INFO,
         clientInfo: CLIENT_INFO,

--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -102,6 +102,17 @@ function getCookies(browser) {
   }).catch(() => []);
 }
 
+// Cookie names that commonly hold session/auth secrets. These are stripped from
+// the snapshot payload by default so credentials aren't forwarded to the Percy
+// daemon and on to the cloud (CWE-200). Set PERCY_FORWARD_ALL_COOKIES=true to
+// restore forwarding the full cookie jar.
+const SENSITIVE_COOKIE_PATTERN = /session|token|auth|sid|jwt|bearer|csrf|xsrf/i;
+
+function filterSensitiveCookies(cookies) {
+  if (process.env.PERCY_FORWARD_ALL_COOKIES === 'true' || !Array.isArray(cookies)) return cookies;
+  return cookies.filter(cookie => !SENSITIVE_COOKIE_PATTERN.test(cookie?.name || ''));
+}
+
 async function captureSerializedDOM(browser, options = {}, utils) {
   const serializeOptions = {
     ...options,
@@ -118,7 +129,7 @@ async function captureSerializedDOM(browser, options = {}, utils) {
   }, [serializeOptions]);
 
   if (!domSnapshot) domSnapshot = {};
-  domSnapshot.cookies = await getCookies(browser);
+  domSnapshot.cookies = filterSensitiveCookies(await getCookies(browser));
 
   return { domSnapshot, url };
 }
@@ -403,5 +414,6 @@ module.exports = {
   slowScrollToBottom,
   ignoreCanvasSerializationErrors,
   ignoreStyleSheetSerializationErrors,
+  filterSensitiveCookies,
   waitForReady
 };

--- a/test/unit/snapshot.test.js
+++ b/test/unit/snapshot.test.js
@@ -7,6 +7,7 @@ const {
   ignoreCanvasSerializationErrors,
   ignoreStyleSheetSerializationErrors,
   slowScrollToBottom,
+  filterSensitiveCookies,
   waitForReady
 } = require('../../lib/snapshot');
 
@@ -30,6 +31,28 @@ describe('snapshot helpers', () => {
     });
   });
 
+  describe('filterSensitiveCookies', () => {
+    afterEach(() => { delete process.env.PERCY_FORWARD_ALL_COOKIES; });
+
+    it('drops session/auth cookies and keeps benign ones (PER-8720)', () => {
+      const cookies = [
+        { name: 'session_id' }, { name: 'jwt' }, { name: 'authToken' },
+        { name: 'csrf' }, { name: 'theme' }, { name: 'cart_id' }
+      ];
+      expect(filterSensitiveCookies(cookies).map(c => c.name)).toEqual(['theme', 'cart_id']);
+    });
+
+    it('forwards all cookies when PERCY_FORWARD_ALL_COOKIES=true', () => {
+      process.env.PERCY_FORWARD_ALL_COOKIES = 'true';
+      const cookies = [{ name: 'session_id' }, { name: 'theme' }];
+      expect(filterSensitiveCookies(cookies)).toEqual(cookies);
+    });
+
+    it('tolerates non-array input', () => {
+      expect(filterSensitiveCookies(undefined)).toBe(undefined);
+    });
+  });
+
   describe('captureSerializedDOM', () => {
     it('injects serialization flags and cookies', async () => {
       const browser = {
@@ -39,7 +62,8 @@ describe('snapshot helpers', () => {
           cb({ value: { domSnapshot: { html: '<html></html>' }, url: 'http://example.com' } });
         },
         getCookies(cb) {
-          cb({ value: [{ name: 'session', value: '123' }] });
+          // a sensitive cookie (filtered out) and a benign one (kept)
+          cb({ value: [{ name: 'session', value: '123' }, { name: 'theme', value: 'dark' }] });
         }
       };
 
@@ -49,7 +73,8 @@ describe('snapshot helpers', () => {
       expect(result.url).toBe('http://example.com');
       expect(result.domSnapshot).toMatchObject({
         html: '<html></html>',
-        cookies: [{ name: 'session', value: '123' }]
+        // session cookie stripped (PER-8720); benign cookie retained
+        cookies: [{ name: 'theme', value: 'dark' }]
       });
       // Options are passed directly to PercyDOM.serialize() which accepts camelCase
       expect(browser.lastArgs).toMatchObject({


### PR DESCRIPTION
## Summary
Two **High**-severity runtime findings in `@percy/nightwatch` (deadline 2026-06-21).

| Ticket | CWE | Finding |
|--------|-----|---------|
| [PER-8720](https://browserstack.atlassian.net/browse/PER-8720) | CWE-200 | Browser session cookies forwarded to Percy daemon unconditionally |
| [PER-8722](https://browserstack.atlassian.net/browse/PER-8722) | CWE-284 / CWE-1321 | Unfiltered options spread into the snapshot POST body |

## Changes
**`lib/snapshot.js` (PER-8720):** `captureSerializedDOM` attached the full cookie jar to every payload. Added `filterSensitiveCookies()` — drops cookies whose name matches `session|token|auth|sid|jwt|bearer|csrf|xsrf` before they're attached. Opt out with `PERCY_FORWARD_ALL_COOKIES=true`.

**`commands/percySnapshot.js` (PER-8722):** caller options were spread verbatim into `postData`. Now sanitized before the spread — prototype-pollution keys (`__proto__`/`constructor`/`prototype`) and code-bearing fields (`execute`/`domTransformation`) are dropped. (`clientInfo`/`environmentInfo` were already hard-coded after the spread, so they stay override-safe.)

## Verification
- **16 unit specs pass** (new `filterSensitiveCookies` cases: drop session/jwt/csrf, keep theme/cart; opt-out; non-array; existing `captureSerializedDOM` test updated for the new default).
- `node --check` clean on both source files.

## Scope note
PER-8722's **full published-schema allowlist** is deferred: a strict allowlist risks dropping legitimate, evolving Percy options, and the CLI already strips the dangerous code fields server-side. This PR removes the prototype-pollution + code-injection vectors; the broad allowlist is flagged on the ticket. The repo's CI-hardening (chain-breaker for C-003 / PER-8731) will follow as a separate PR.

Closes PER-8720; addresses PER-8722 (proto-pollution/code-field legs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PER-8720]: https://browserstack.atlassian.net/browse/PER-8720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PER-8722]: https://browserstack.atlassian.net/browse/PER-8722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ